### PR TITLE
Fix "Int cannot represent non-integer value" for karma and total coins (GraphQL)

### DIFF
--- a/processors/processPlayerData.js
+++ b/processors/processPlayerData.js
@@ -159,6 +159,7 @@ function processPlayerData({
   const newRankPlusColor = colorNameToCode(rankPlusColor);
   const newPrefix = betterFormatting(prefix);
   const rankPlusPlusColor = colorNameToCode(monthlyRankColor);
+  karma = karma.toFixed(0);
   return {
     uuid,
     username: displayname,
@@ -176,7 +177,7 @@ function processPlayerData({
     total_games_played: totalGamesPlayed,
     total_kills: totalKills,
     total_wins: totalWins,
-    total_coins: totalCoins,
+    total_coins: totalCoins.toFixed(0),
     mc_version: mcVersionRp,
     first_login: getFirstLogin(firstLogin, _id),
     last_login: lastLogin,


### PR DESCRIPTION
Added .toFixed(0) to karma and totalcoins to make sure that it's an integer being returned and not a non-integer value